### PR TITLE
解いた問題にAcronymを追加

### DIFF
--- a/ruby/acronym/acronym.rb
+++ b/ruby/acronym/acronym.rb
@@ -1,0 +1,8 @@
+=begin
+Write your code for the 'Acronym' exercise in this file. Make the tests in
+`acronym_test.rb` pass.
+
+To get started with TDD, see the `README.md` file in your
+`ruby/acronym` directory.
+=end
+

--- a/ruby/acronym/acronym.rb
+++ b/ruby/acronym/acronym.rb
@@ -8,6 +8,6 @@ To get started with TDD, see the `README.md` file in your
 
 class Acronym
   def self.abbreviate(long_name)
-    'PNG'
+    long_name.split.map { |word| word.slice(0).upcase }.join
   end
 end

--- a/ruby/acronym/acronym.rb
+++ b/ruby/acronym/acronym.rb
@@ -8,6 +8,6 @@ To get started with TDD, see the `README.md` file in your
 
 class Acronym
   def self.abbreviate(long_name)
-    long_name.split.map { |word| word.slice(0).upcase }.join
+    long_name.gsub('-', ' ').split.map { |word| word.slice(0).upcase }.join
   end
 end

--- a/ruby/acronym/acronym.rb
+++ b/ruby/acronym/acronym.rb
@@ -8,6 +8,6 @@ To get started with TDD, see the `README.md` file in your
 
 class Acronym
   def self.abbreviate(long_name)
-    long_name.gsub('-', ' ').split.map { |word| word.slice(0).upcase }.join
+    long_name.gsub('-', ' ').split.map { |word| word.slice(0) }.join.upcase
   end
 end

--- a/ruby/acronym/acronym.rb
+++ b/ruby/acronym/acronym.rb
@@ -6,3 +6,8 @@ To get started with TDD, see the `README.md` file in your
 `ruby/acronym` directory.
 =end
 
+class Acronym
+  def self.abbreviate(long_name)
+    'PNG'
+  end
+end

--- a/ruby/acronym/acronym.rb
+++ b/ruby/acronym/acronym.rb
@@ -8,6 +8,6 @@ To get started with TDD, see the `README.md` file in your
 
 class Acronym
   def self.abbreviate(long_name)
-    long_name.gsub('-', ' ').split.map { |word| word.slice(0) }.join.upcase
+    long_name.tr('-', ' ').split.map { |word| word.slice(0) }.join.upcase
   end
 end

--- a/ruby/acronym/acronym_test.rb
+++ b/ruby/acronym/acronym_test.rb
@@ -1,0 +1,40 @@
+require 'minitest/autorun'
+require_relative 'acronym'
+
+# Common test data version: 1.7.0 cacf1f1
+class AcronymTest < Minitest::Test
+  def test_basic
+    # skip
+    assert_equal "PNG", Acronym.abbreviate('Portable Network Graphics')
+  end
+
+  def test_lowercase_words
+    skip
+    assert_equal "ROR", Acronym.abbreviate('Ruby on Rails')
+  end
+
+  def test_punctuation
+    skip
+    assert_equal "FIFO", Acronym.abbreviate('First In, First Out')
+  end
+
+  def test_all_caps_word
+    skip
+    assert_equal "GIMP", Acronym.abbreviate('GNU Image Manipulation Program')
+  end
+
+  def test_punctuation_without_whitespace
+    skip
+    assert_equal "CMOS", Acronym.abbreviate('Complementary metal-oxide semiconductor')
+  end
+
+  def test_very_long_abbreviation
+    skip
+    assert_equal "ROTFLSHTMDCOALM", Acronym.abbreviate('Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me')
+  end
+
+  def test_consecutive_delimiters
+    skip
+    assert_equal "SIMUFTA", Acronym.abbreviate('Something - I made up from thin air')
+  end
+end

--- a/ruby/acronym/acronym_test.rb
+++ b/ruby/acronym/acronym_test.rb
@@ -9,7 +9,7 @@ class AcronymTest < Minitest::Test
   end
 
   def test_lowercase_words
-    skip
+    # skip
     assert_equal "ROR", Acronym.abbreviate('Ruby on Rails')
   end
 

--- a/ruby/acronym/acronym_test.rb
+++ b/ruby/acronym/acronym_test.rb
@@ -14,22 +14,22 @@ class AcronymTest < Minitest::Test
   end
 
   def test_punctuation
-    skip
+    # skip
     assert_equal "FIFO", Acronym.abbreviate('First In, First Out')
   end
 
   def test_all_caps_word
-    skip
+    # skip
     assert_equal "GIMP", Acronym.abbreviate('GNU Image Manipulation Program')
   end
 
   def test_punctuation_without_whitespace
-    skip
+    # skip
     assert_equal "CMOS", Acronym.abbreviate('Complementary metal-oxide semiconductor')
   end
 
   def test_very_long_abbreviation
-    skip
+    # skip
     assert_equal "ROTFLSHTMDCOALM", Acronym.abbreviate('Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me')
   end
 

--- a/ruby/acronym/acronym_test.rb
+++ b/ruby/acronym/acronym_test.rb
@@ -34,7 +34,7 @@ class AcronymTest < Minitest::Test
   end
 
   def test_consecutive_delimiters
-    skip
+    # skip
     assert_equal "SIMUFTA", Acronym.abbreviate('Something - I made up from thin air')
   end
 end


### PR DESCRIPTION
## 目的
- 新たに問題をといた

## 変更後
- Acronym問題を解いた問題に追加
- Acronym問題とは
    - 与えられた文字列を空白文字もしくは`-`で単語に分割する。
    - 各単語の一文字目を結合した結果を返す
    - 結果は全て大文字になる